### PR TITLE
versioning: calculate version number nicely whether or not within git repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,12 +39,16 @@ dir:
 
 version.h:
 	mkdir -p $(BUILD_DIR)/include
-	echo "#define SYNCIT_MAJOR $(SYNCIT_MAJOR)" > $(BUILD_DIR)/include/$@
-	echo "#define SYNCIT_MINOR $(SYNCIT_MINOR)" >> $(BUILD_DIR)/include/$@
-	echo "#define SYNCIT_PATCH $(SYNCIT_PATCH)" >> $(BUILD_DIR)/include/$@
+	echo "#define SYNCIT_MAJOR \"$(SYNCIT_MAJOR)\"" > $(BUILD_DIR)/include/$@
+	echo "#define SYNCIT_MINOR \"$(SYNCIT_MINOR)\"" >> $(BUILD_DIR)/include/$@
+	echo "#define SYNCIT_PATCH \"$(SYNCIT_PATCH)\"" >> $(BUILD_DIR)/include/$@
+ifeq ($(shell git rev-parse; echo $$?),0)
 	echo -n '#define SYNCIT_GITHASH "' >> $(BUILD_DIR)/include/$@
 	git rev-parse --short HEAD | tr -d "\n" >> $(BUILD_DIR)/include/$@
 	echo '"' >> $(BUILD_DIR)/include/$@
+else
+	$(info Not running in git.)
+endif
 
 $(BUILD_DIR)/obj/main.o: version.h $(SRC_DIR)/src/main.c
 	$(CC) -c $(CFLAGS) $(SRC_DIR)/src/main.c -o $(BUILD_DIR)/obj/main.o

--- a/src/main.c
+++ b/src/main.c
@@ -26,6 +26,12 @@
 #include "sync.h"
 #include "version.h"
 
+#ifdef SYNCIT_GITHASH
+#define SYNCIT_VERSION SYNCIT_MAJOR "." SYNCIT_MINOR "." SYNCIT_PATCH "+" SYNCIT_GITHASH
+#else
+#define SYNCIT_VERSION SYNCIT_MAJOR "." SYNCIT_MINOR "." SYNCIT_PATCH
+#endif
+
 int current_logger_level = LOGGER_ERROR;
 
 /*
@@ -34,7 +40,7 @@ int current_logger_level = LOGGER_ERROR;
  * Print help message for this tool.
  */
 void help() {
-	printf("syncit v%d.%d.%d+%s\n", SYNCIT_MAJOR, SYNCIT_MINOR, SYNCIT_PATCH, SYNCIT_GITHASH);
+	printf("syncit v%s\n", SYNCIT_VERSION);
 	printf("Usage: syncit [-d|--debug] [-h|--help] [-v|--version] [-f file] [file]\n");
 }
 
@@ -64,7 +70,7 @@ int main(int argc, char * argv[]) {
 				current_logger_level = LOGGER_DEBUG;
 				break;
 			case 'v':
-				printf("v%d.%d.%d+%s\n", SYNCIT_MAJOR, SYNCIT_MINOR, SYNCIT_PATCH, SYNCIT_GITHASH);
+				printf("v%s\n", SYNCIT_VERSION);
 				exit(EXIT_SUCCESS);
 				break;
 			case 'f':


### PR DESCRIPTION
Revamp the version number calculation and remove some redundancy in code.
Now not in git repo it will have `v0.0.1` and similar, while
in git repo will have simething like `v0.0.1+159e752`.

Closes #1